### PR TITLE
chore: update README framework reference from net6.0 to net8.0 and fix sln name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This is a .NET Core application that can be built on any platform where .NET is 
     export LAUNCHDARKLY_FLAG_KEY="my-boolean-flag"
     ```
 
-2. If you are using Visual Studio, open `HelloDotNet.sln` and run the application. Or, to run from the command line, type the following command:
+2. If you are using Visual Studio, open `HelloOpenFeatureDotnet.sln` and run the application. Or, to run from the command line, type the following command:
 
 ```
-     dotnet run --project HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj --framework net6.0
+     dotnet run --project HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj --framework net8.0
 ```
 
 You should see the message `"The <flag key> feature flag evaluates to <true/false>"`.


### PR DESCRIPTION
## Summary

The README had two inaccuracies:
- Referenced `HelloDotNet.sln` instead of the actual `HelloOpenFeatureDotnet.sln`
- Referenced `--framework net6.0` (EOL) instead of `net8.0`, which is what CI already uses

No code changes needed — the existing version constraints already resolve to the latest packages:
- `LaunchDarkly.OpenFeature.ServerProvider` 2.1.2
- `OpenFeature` 2.13.0
- `LaunchDarkly.ServerSdk` 8.5.1+ (within `[8.5.1, 9.0.0)`)

No deprecated API usage was found in the source code. Build and run verified successfully.

Link to Devin session: https://app.devin.ai/sessions/7260c50ea7a7408ba2c195f1492b7c0e
Requested by: @kinyoklion