### PR TITLE
chore: use floating 8.* for LaunchDarkly.ServerSdk

### DIFF
--- a/HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj
+++ b/HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.OpenFeature.ServerProvider" Version="2.*" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.14.0, 9.0.0)" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.*" />
     <PackageReference Include="OpenFeature" Version="2.*" />
   </ItemGroup>
 

--- a/HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj
+++ b/HelloOpenFeatureDotnet/HelloOpenFeatureDotnet.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.OpenFeature.ServerProvider" Version="2.*" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.5.1, 9.0.0)" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.14.0, 9.0.0)" />
     <PackageReference Include="OpenFeature" Version="2.*" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Changes the `LaunchDarkly.ServerSdk` `PackageReference` to a floating version so restore always resolves the latest 8.x, matching the pattern already used by the other two packages in this project (`LaunchDarkly.OpenFeature.ServerProvider` and `OpenFeature`, both `2.*`).

```diff
- <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.14.0, 9.0.0)" />
+ <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.*" />
```

For SDK-style `PackageReference` projects, a floating version *is* NuGet's "resolve to latest" mechanism — with a closed range like `[8.14.0, 9.0.0)` NuGet restores the lowest matching version, whereas `8.*` restores the highest 8.x.

Verified with `dotnet restore` / `dotnet list package`: `8.*` resolves to **8.14.1** (current latest 8.x), and the project builds cleanly (`net8.0`, Release).

Link to Devin session: https://app.devin.ai/sessions/8148ac8939db4960ab05f5ce5b6e061d
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version constraint only in a sample project; no application or security logic changes.
> 
> **Overview**
> Updates **`LaunchDarkly.ServerSdk`** in `HelloOpenFeatureDotnet.csproj` from a bounded NuGet range to **`8.*`**, so restore picks the latest 8.x instead of the lowest version in a closed interval.
> 
> This aligns **`LaunchDarkly.ServerSdk`** with the other dependencies in the sample (`LaunchDarkly.OpenFeature.ServerProvider` and `OpenFeature` already use `2.*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56b821b796a6e15c81f0eebee388d95ae0becce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->