### PR TITLE
docs: Add a moved notice pointing to examples-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **These examples have moved.** The OpenFeature .NET server provider examples now live in the [examples-dotnet repository](https://github.com/launchdarkly/examples-dotnet). This repository remains to support legacy references.
+
 # LaunchDarkly Sample OpenFeature .Net Server application
 
 We've built a simple console that demonstrates how LaunchDarkly's OpenFeature provider works.


### PR DESCRIPTION
## Summary

Prepends a GitHub `[!IMPORTANT]` notice to the README pointing users to **[launchdarkly/examples-dotnet](https://github.com/launchdarkly/examples-dotnet)**, where the OpenFeature .NET server provider examples now live. Original README kept intact below.

**Merge order:** merge **before** the Terraform archive PR for this repo (an archived repo is read-only).

Part of SDK-2562.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code or runtime impact.
> 
> **Overview**
> Adds a GitHub **`[!IMPORTANT]`** callout at the top of **`README.md`** directing readers to **[launchdarkly/examples-dotnet](https://github.com/launchdarkly/examples-dotnet)** for the current OpenFeature .NET server provider examples, and notes this repo stays up for legacy links.
> 
> The rest of the README is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f58573a9b32e5c9b40b267a007f10dbac4d1ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->